### PR TITLE
fix(install): detect *.code-workspace as valid workspace root for multi-root workspaces

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -115,16 +115,36 @@ if ($IsBootstrap) {
 else {
     # Running from an existing speckit directory — resolve workspace root
     if (-not $WorkspaceRoot) {
-        $WorkspaceRoot = (Resolve-Path (Join-Path $SpeckitRoot '..\..\..'))
+        # Walk up from the speckit source directory to find a .git or *.code-workspace
+        $candidate = Split-Path -Parent $SpeckitRoot
+        $found = $false
+        while ($candidate) {
+            $hasGitDir      = Test-Path (Join-Path $candidate '.git')
+            $hasWorkspace   = [bool](Get-ChildItem $candidate -Filter '*.code-workspace' -ErrorAction SilentlyContinue | Select-Object -First 1)
+            if ($hasGitDir -or $hasWorkspace) {
+                $WorkspaceRoot = $candidate
+                $found = $true
+                break
+            }
+            $parent = Split-Path -Parent $candidate
+            if ($parent -eq $candidate) { break }   # reached filesystem root
+            $candidate = $parent
+        }
+        if (-not $found) {
+            # Fallback: three levels up from speckit source (legacy behaviour)
+            $WorkspaceRoot = (Resolve-Path (Join-Path $SpeckitRoot '..\..\..'))
+        }
     }
     else {
         $WorkspaceRoot = (Resolve-Path $WorkspaceRoot)
     }
 }
 
-# Validate workspace root looks like a git repository
-if (-not (Test-Path (Join-Path $WorkspaceRoot '.git'))) {
-    Write-Warning "Workspace root '$WorkspaceRoot' does not contain a .git directory. Verify the path is correct."
+# Validate workspace root looks like a project root (.git) or a VS Code multi-root workspace (*.code-workspace)
+$wsHasGit       = Test-Path (Join-Path $WorkspaceRoot '.git')
+$wsHasWorkspace = [bool](Get-ChildItem $WorkspaceRoot -Filter '*.code-workspace' -ErrorAction SilentlyContinue | Select-Object -First 1)
+if (-not $wsHasGit -and -not $wsHasWorkspace) {
+    Write-Warning "Workspace root '$WorkspaceRoot' does not contain a .git directory or *.code-workspace file. Verify the path is correct."
 }
 $GithubDir  = Join-Path $WorkspaceRoot '.github'
 $SkillsDir  = Join-Path $GithubDir 'skills'


### PR DESCRIPTION
## Problem

When speckit source lives outside a git repo  the typical VS Code multi-root workspace setup (e.g. \d:\dev\himyatra\speckit\ alongside \himyatra.code-workspace\)  the installer had two issues:

1. **Wrong auto-detection**: Without \-WorkspaceRoot\, the script resolved the workspace root as \(Resolve-Path \..\..\..\')\ from the speckit source dir. For \d:\dev\himyatra\speckit\, this resolved to \D:\\\ instead of \d:\dev\himyatra\.
2. **False-positive warning**: The workspace root validation only accepted \.git\ directories, so every multi-root workspace install showed a warning even when the root was perfectly valid.

## Fix

- **Walk-up detection**: Instead of a fixed 3-level climb, walk up from the speckit source dir looking for \.git\ OR \*.code-workspace\, then fall back to the 3-level heuristic only if neither is found.
- **Updated validation**: Accept \*.code-workspace\ as a valid workspace root marker alongside \.git\.

## Tested on

- \d:\dev\himyatra\  multi-root workspace with \himyatra.code-workspace\, 3 sub-repos. Auto-detection now correctly resolves to \D:\dev\himyatra\ with no warning.