### PR TITLE
fix: detect user vs org owner for GraphQL project queries

### DIFF
--- a/scripts/set-issue-state.ps1
+++ b/scripts/set-issue-state.ps1
@@ -75,6 +75,15 @@ if ($Owner -eq "@me") {
     $resolvedOwner = (gh api user --jq '.login') 2>&1
 }
 
+# -- Detect owner type (user vs org) ----
+$ownerType = (gh api "users/$resolvedOwner" --jq '.type') 2>&1
+if ($ownerType -eq 'Organization') {
+    $gqlOwnerRoot = 'organization'
+} else {
+    $gqlOwnerRoot = 'user'
+}
+Write-Host "Owner '$resolvedOwner' is a $ownerType (using $gqlOwnerRoot GraphQL root)" -ForegroundColor White
+
 # -- Step 1: Get the field ID and option ID ----
 Write-Host "Finding field '$FieldName' option '$State'..." -ForegroundColor Yellow
 
@@ -124,9 +133,11 @@ Write-Host "  Issue #${IssueNumber}: $($issueData.title)" -ForegroundColor White
 # -- Step 3: Find the project item ID for this issue ----
 Write-Host "Finding project item..." -ForegroundColor Yellow
 
-$projectQuery = 'query { user(login: \"' + $resolvedOwner + '\") { projectV2(number: ' + $ProjectNumber + ') { id items(first: 100) { nodes { id content { ... on Issue { id number } } } } } } }'
+$projectQuery = 'query { ' + $gqlOwnerRoot + '(login: \"' + $resolvedOwner + '\") { projectV2(number: ' + $ProjectNumber + ') { id items(first: 100) { nodes { id content { ... on Issue { id number } } } } } } }'
 
-$projectData = (gh api graphql -f query="$projectQuery" --jq '.data.user.projectV2') 2>&1 | ConvertFrom-Json
+$gqlJqPath = '.data.' + $gqlOwnerRoot + '.projectV2'
+
+$projectData = (gh api graphql -f query="$projectQuery" --jq "$gqlJqPath") 2>&1 | ConvertFrom-Json
 $projectId = $projectData.id
 
 $projectItem = $projectData.items.nodes | Where-Object { $_.content.id -eq $issueNodeId }

--- a/scripts/setup-project-board.ps1
+++ b/scripts/setup-project-board.ps1
@@ -131,9 +131,19 @@ if ($Owner -eq "@me") {
     $resolvedOwner = (gh api user --jq '.login') 2>&1
 }
 
-$projectQuery = 'query { user(login: \"' + $resolvedOwner + '\") { projectV2(number: ' + $ProjectNumber + ') { id views(first: 20) { nodes { id name layout } } } } }'
+# -- Detect owner type (user vs org) ----
+$ownerType = (gh api "users/$resolvedOwner" --jq '.type') 2>&1
+if ($ownerType -eq 'Organization') {
+    $gqlOwnerRoot = 'organization'
+} else {
+    $gqlOwnerRoot = 'user'
+}
+Write-Host "  Owner '$resolvedOwner' is a $ownerType (using $gqlOwnerRoot GraphQL root)" -ForegroundColor White
 
-$projectData = (gh api graphql -f query="$projectQuery" --jq '.data.user.projectV2') 2>&1 | ConvertFrom-Json
+$projectQuery = 'query { ' + $gqlOwnerRoot + '(login: \"' + $resolvedOwner + '\") { projectV2(number: ' + $ProjectNumber + ') { id views(first: 20) { nodes { id name layout } } } } }'
+
+$gqlJqPath = '.data.' + $gqlOwnerRoot + '.projectV2'
+$projectData = (gh api graphql -f query="$projectQuery" --jq "$gqlJqPath") 2>&1 | ConvertFrom-Json
 $projectId = $projectData.id
 
 Write-Host "  Project node ID: $projectId" -ForegroundColor White


### PR DESCRIPTION
## Problem

Both `scripts/set-issue-state.ps1` and `scripts/setup-project-board.ps1` hardcoded `user(login:...)` as the GraphQL root for project queries. This breaks for **organization-owned** GitHub Projects, which require `organization(login:...)`.

## Fix

Before issuing GraphQL queries, detect the owner type via `gh api users/{owner}`:
- If `type` is `Organization` → use `organization(login:...)` 
- Otherwise → use `user(login:...)`

The `--jq` path is also dynamically built to match the selected root.

## Files changed

- `scripts/set-issue-state.ps1` — owner type detection + dynamic GraphQL root
- `scripts/setup-project-board.ps1` — same fix