### PR TITLE
fix(install): handle scriptblock invocation in bootstrap path resolution

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -104,7 +104,21 @@ function Get-SpeckitFromGitHub {
 
 # --- Resolve paths -----------------------------------------------------------
 $SpeckitRoot = $PSScriptRoot
-if (-not $SpeckitRoot) { $SpeckitRoot = Split-Path -Parent $MyInvocation.MyCommand.Definition }
+if (-not $SpeckitRoot) {
+    # When invoked via [scriptblock]::Create (web bootstrap), $PSScriptRoot is
+    # empty and $MyInvocation.MyCommand.Definition returns the script body
+    # (not a path), which would cause Split-Path to throw "Illegal characters
+    # in path". Try to derive a path; if anything fails, leave $SpeckitRoot
+    # null so bootstrap mode kicks in below.
+    try {
+        $invocationPath = $MyInvocation.MyCommand.Definition
+        if ($invocationPath -and (Test-Path -LiteralPath $invocationPath -ErrorAction SilentlyContinue)) {
+            $SpeckitRoot = Split-Path -Parent $invocationPath
+        }
+    } catch {
+        $SpeckitRoot = $null
+    }
+}
 
 # Detect bootstrap mode: running from web (scriptblock::Create) or no valid speckit root
 $IsBootstrap = (-not $SpeckitRoot) -or (-not (Test-Path (Join-Path $SpeckitRoot 'SKILL.md')))


### PR DESCRIPTION
## What

Fixes the README's recommended one-liner crash:

````
powershell
& ([scriptblock]::Create((Invoke-RestMethod https://raw.githubusercontent.com/ranvirsingh/speckit/main/install.ps1)))
# Split-Path : Illegal characters in path.
````

## Root cause

When invoked via `scriptblock::Create`, `$PSScriptRoot` is empty AND `MyInvocation.MyCommand.Definition` returns the script body string (not a path). The fallback `Split-Path -Parent` blows up before bootstrap mode can detect it should bootstrap.

## Fix

Wrap the fallback in try/catch with a `Test-Path -LiteralPath` guard. If anything fails, leave `SpeckitRoot` null so bootstrap mode kicks in correctly.

## Verification

Found while running the canonical one-liner from the v2.0.0 README against billfusion. Will re-validate after merge.

## Speckit checklist

- [x] specify (issue #13)
- [ ] research (skip-speckit: research \u2014 root cause already isolated, no unknowns)
- [ ] plan (skip-speckit: plan \u2014 single-file 15-line change)
- [x] implement
- [ ] test (skip-speckit: test \u2014 no automated UAT harness for install.ps1; manual verification post-merge)
- [ ] e2e (skip-speckit: e2e \u2014 install path is OS-shell, not UI/API)

Closes #13