### PR TITLE
feat(hooks): add implementation guard hooks

### DIFF
--- a/.github/workflows/pipeline-guard.yml
+++ b/.github/workflows/pipeline-guard.yml
@@ -20,6 +20,11 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Validate PR body
         uses: actions/github-script@v7
         with:
@@ -56,3 +61,14 @@ jobs:
             } else {
               core.info('Speckit pipeline guard passed.');
             }
+
+      - name: Run before_pr guard
+        shell: pwsh
+        run: |
+          if (Test-Path ./scripts/invoke-before-pr-guard.ps1) {
+            ./scripts/invoke-before-pr-guard.ps1 -WorkspaceRoot "." -BaseRef "${{ github.event.pull_request.base.sha }}"
+          } elseif (Test-Path ./.github/skills/speckit/scripts/invoke-before-pr-guard.ps1) {
+            ./.github/skills/speckit/scripts/invoke-before-pr-guard.ps1 -WorkspaceRoot "." -BaseRef "${{ github.event.pull_request.base.sha }}"
+          } else {
+            throw "before_pr guard script not found."
+          }

--- a/references/HOOKS.md
+++ b/references/HOOKS.md
@@ -15,6 +15,66 @@ Each skill checks for hooks at a specific lifecycle point (e.g., `before_specify
 | `speckit-test` | `hooks.before_test` | `hooks.after_test` |
 | `speckit-e2e` | `hooks.before_e2e` | `hooks.after_e2e` |
 
+## Bundled Hook Implementations
+
+Speckit ships concrete guards for safety-critical hook keys. Other hook keys
+remain extension surfaces until a project registers commands in
+`.specify/extensions.yml`.
+
+| Hook key | Bundled implementation | Status |
+|----------|------------------------|--------|
+| `hooks.before_specify` | Extension surface only | Stub |
+| `hooks.after_specify` | Extension surface only | Stub |
+| `hooks.before_research` | Extension surface only | Stub |
+| `hooks.after_research` | Extension surface only | Stub |
+| `hooks.before_plan` | Extension surface only | Stub |
+| `hooks.after_plan` | Extension surface only | Stub |
+| `hooks.before_implement` | `scripts/invoke-before-implement-guard.ps1` | Implemented |
+| `hooks.after_implement` | Extension surface only | Stub |
+| `hooks.before_pr` | `scripts/invoke-before-pr-guard.ps1` | Implemented |
+| `hooks.after_pr` | Extension surface only | Stub |
+| `hooks.before_test` | Extension surface only | Stub |
+| `hooks.after_test` | Extension surface only | Stub |
+| `hooks.before_e2e` | Extension surface only | Stub |
+| `hooks.after_e2e` | Extension surface only | Stub |
+| `hooks.before_verify` | Extension surface only | Stub |
+| `hooks.after_verify` | Extension surface only | Stub |
+
+### `before_implement`: Frozen Edit Paths
+
+Run this hook after loading the issue and before editing files. It extracts
+workspace-relative paths from the issue `## Scope`, `## Affected Files`,
+`## Files`, or `## Implementation Scope` section and writes
+`.specify/frozen-edit-paths.json`.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/invoke-before-implement-guard.ps1 `
+  -WorkspaceRoot "." `
+  -IssueBody "{issue body markdown}"
+```
+
+If the scope is intentionally empty, pass `-AllowedPath` values explicitly or
+use `-AllowEmpty` for documentation-only work.
+
+### `before_pr`: Destructive-Change Scan and TODO Triage
+
+Run this hook before marking a PR ready. It checks the branch diff against
+`main` by default and fails when:
+
+- A file is deleted or renamed without `-AllowDestructive`.
+- A changed path falls outside `.specify/frozen-edit-paths.json`.
+- The branch introduces `TODO(speckit)` markers that have not been triaged into
+  an issue or `docs/PARKING_LOT.md`.
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/invoke-before-pr-guard.ps1 `
+  -WorkspaceRoot "." `
+  -BaseRef "main"
+```
+
+Use `-AllowUntriagedTodo` only while drafting the PR body; ready-for-review PRs
+should have every introduced `TODO(speckit)` parked or converted to an issue.
+
 `before_pr` runs after the implementation is complete but before
 `gh pr create` is executed. The default behaviour for `speckit-implement`
 when this hook resolves to no entries is to force `--draft`, locally validate

--- a/scripts/invoke-before-implement-guard.ps1
+++ b/scripts/invoke-before-implement-guard.ps1
@@ -1,0 +1,97 @@
+<#
+.SYNOPSIS
+    Freezes the allowed edit paths for a speckit implementation.
+
+.DESCRIPTION
+    Reads the issue scope and writes .specify/frozen-edit-paths.json. The
+    before_pr guard uses that file to block changes outside the declared scope.
+#>
+[CmdletBinding()]
+param(
+    [string]$WorkspaceRoot = (Get-Location),
+    [string]$IssueBody,
+    [string[]]$AllowedPath = @(),
+    [switch]$AllowEmpty
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-NormalizedPath {
+    param([string]$Path)
+
+    $normalized = $Path.Trim().Trim('`').Trim('"').Trim("'") -replace '\\', '/'
+    $normalized = $normalized.TrimStart('./')
+    if ($normalized -match '(^|/)\.\.(/|$)' -or [System.IO.Path]::IsPathRooted($normalized)) {
+        throw "Path '$Path' must be a workspace-relative path."
+    }
+    return $normalized.TrimEnd('/')
+}
+
+function Get-ScopePathFromIssueBody {
+    param([string]$Body)
+
+    if (-not $Body) { return @() }
+
+    $paths = New-Object System.Collections.Generic.List[string]
+    $inScope = $false
+
+    foreach ($line in ($Body -split "`r?`n")) {
+        if ($line -match '^#{2,6}\s+(Scope|Affected Files|Files|Implementation Scope)\s*$') {
+            $inScope = $true
+            continue
+        }
+        if ($inScope -and $line -match '^#{2,6}\s+') { break }
+        if (-not $inScope) { continue }
+
+        foreach ($match in [regex]::Matches($line, '`([^`]+)`')) {
+            $candidate = $match.Groups[1].Value
+            if ($candidate -match '[./\\]' -or $candidate -match '\.[A-Za-z0-9]+$') {
+                $paths.Add($candidate)
+            }
+        }
+
+        if ($line -match '^\s*[-*]\s+([A-Za-z0-9_.\-/\\]+)\s*$') {
+            $candidate = $Matches[1]
+            if ($candidate -match '[./\\]' -or $candidate -match '\.[A-Za-z0-9]+$') {
+                $paths.Add($candidate)
+            }
+        }
+    }
+
+    return $paths.ToArray()
+}
+
+$workspace = (Resolve-Path -LiteralPath $WorkspaceRoot).Path
+$scopePaths = @()
+$scopePaths += $AllowedPath
+$scopePaths += Get-ScopePathFromIssueBody -Body $IssueBody
+
+$normalizedPaths = @(
+    $scopePaths |
+        Where-Object { $_ -and $_.Trim() } |
+        ForEach-Object { ConvertTo-NormalizedPath -Path $_ } |
+        Sort-Object -Unique
+)
+
+if ($normalizedPaths.Count -eq 0 -and -not $AllowEmpty) {
+    throw 'No allowed edit paths were found. Add scoped paths to the issue body or pass -AllowedPath.'
+}
+
+$specifyDir = Join-Path $workspace '.specify'
+if (-not (Test-Path -LiteralPath $specifyDir)) {
+    New-Item -ItemType Directory -Path $specifyDir -Force | Out-Null
+}
+
+$freezePath = Join-Path $specifyDir 'frozen-edit-paths.json'
+$payload = [ordered]@{
+    schemaVersion = 1
+    createdAt     = (Get-Date -Format 'o')
+    allowedPaths  = $normalizedPaths
+}
+
+$payload | ConvertTo-Json -Depth 4 | Set-Content -Path $freezePath -Encoding UTF8
+Write-Output "Frozen edit paths written to .specify/frozen-edit-paths.json"
+foreach ($path in $normalizedPaths) {
+    Write-Output "  - $path"
+}

--- a/scripts/invoke-before-pr-guard.ps1
+++ b/scripts/invoke-before-pr-guard.ps1
@@ -1,0 +1,114 @@
+<#
+.SYNOPSIS
+    Runs speckit before_pr guard checks.
+
+.DESCRIPTION
+    Blocks destructive changes, changes outside frozen edit paths, and
+    untriaged TODO(speckit) markers introduced by the current branch.
+#>
+[CmdletBinding()]
+param(
+    [string]$WorkspaceRoot = (Get-Location),
+    [string]$BaseRef = 'main',
+    [string]$FrozenPathsFile,
+    [switch]$AllowDestructive,
+    [switch]$AllowUntriagedTodo
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+function ConvertTo-NormalizedPath {
+    param([string]$Path)
+    return (($Path.Trim() -replace '\\', '/').TrimStart('./')).TrimEnd('/')
+}
+
+function Test-IsPathAllowed {
+    param(
+        [string]$ChangedPath,
+        [string[]]$AllowedPaths
+    )
+
+    $changed = ConvertTo-NormalizedPath -Path $ChangedPath
+    foreach ($allowed in $AllowedPaths) {
+        $scope = ConvertTo-NormalizedPath -Path $allowed
+        if ($changed -eq $scope -or $changed.StartsWith("$scope/")) {
+            return $true
+        }
+    }
+    return $false
+}
+
+$workspace = (Resolve-Path -LiteralPath $WorkspaceRoot).Path
+Push-Location $workspace
+try {
+    git rev-parse --is-inside-work-tree | Out-Null
+    if ($LASTEXITCODE -ne 0) { throw 'WorkspaceRoot is not inside a git worktree.' }
+
+    $mergeBase = (git merge-base $BaseRef HEAD 2>$null)
+    if ($LASTEXITCODE -ne 0 -or -not $mergeBase) {
+        $mergeBase = $BaseRef
+    }
+
+    $nameStatus = @(git diff --name-status $mergeBase HEAD)
+    $diffText = (git diff --unified=0 $mergeBase HEAD)
+
+    $errors = New-Object System.Collections.Generic.List[string]
+    $warnings = New-Object System.Collections.Generic.List[string]
+
+    $destructive = @(
+        $nameStatus |
+            Where-Object { $_ -match '^(D|R\d{0,3})\s+' }
+    )
+    if ($destructive.Count -gt 0 -and -not $AllowDestructive) {
+        $errors.Add("Destructive changes detected:`n  - $($destructive -join "`n  - ")")
+    }
+
+    if (-not $FrozenPathsFile) {
+        $FrozenPathsFile = Join-Path $workspace '.specify/frozen-edit-paths.json'
+    }
+
+    if (Test-Path -LiteralPath $FrozenPathsFile) {
+        $frozen = Get-Content -LiteralPath $FrozenPathsFile -Raw | ConvertFrom-Json
+        $allowedPaths = @($frozen.allowedPaths)
+        if ($allowedPaths.Count -gt 0) {
+            foreach ($line in $nameStatus) {
+                $parts = $line -split "`t"
+                $changedPath = if ($parts.Count -ge 3 -and $parts[0] -match '^R') { $parts[2] } else { $parts[-1] }
+                if (-not (Test-IsPathAllowed -ChangedPath $changedPath -AllowedPaths $allowedPaths)) {
+                    $errors.Add("Change outside frozen edit paths: $changedPath")
+                }
+            }
+        }
+    }
+    else {
+        $warnings.Add('No frozen edit path file found at .specify/frozen-edit-paths.json.')
+    }
+
+    $introducedTodos = @(
+        $diffText -split "`r?`n" |
+            Where-Object { $_ -match '^\+\s*(#|//|/\*|\*)\s*TODO\(speckit\)' }
+    )
+    if ($introducedTodos.Count -gt 0) {
+        $todoSummary = "Introduced TODO(speckit) markers:`n  - $($introducedTodos -join "`n  - ")"
+        if ($AllowUntriagedTodo) {
+            $warnings.Add($todoSummary)
+        }
+        else {
+            $errors.Add("$todoSummary`nTriage them into an issue or docs/PARKING_LOT.md before marking the PR ready.")
+        }
+    }
+
+    foreach ($warning in $warnings) {
+        Write-Warning $warning
+    }
+
+    if ($errors.Count -gt 0) {
+        throw "before_pr guard failed:`n- $($errors -join "`n- ")"
+    }
+
+    Write-Output 'before_pr guard passed.'
+}
+finally {
+    Pop-Location
+}

--- a/scripts/speckit.tests.ps1
+++ b/scripts/speckit.tests.ps1
@@ -6,14 +6,27 @@
     Run with: Invoke-Pester -Path scripts/speckit.tests.ps1
 #>
 
+$script:SpeckitTestRoot = Join-Path (Split-Path $PSScriptRoot -Parent) '.tmp'
+if (-not (Test-Path $script:SpeckitTestRoot)) {
+    New-Item -ItemType Directory -Path $script:SpeckitTestRoot -Force | Out-Null
+}
+$env:TEMP = $script:SpeckitTestRoot
+$env:TMP = $script:SpeckitTestRoot
+
+function New-SpeckitTestDirectory {
+    $root = $script:SpeckitTestRoot
+    $tempDir = Join-Path $root "speckit-test-$(Get-Random)"
+    New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+    return $tempDir
+}
+
 Describe 'check-constitution.ps1' {
     BeforeAll {
         $scriptPath = Join-Path $PSScriptRoot 'check-constitution.ps1'
     }
 
     It 'returns exists=false when no constitution file' {
-        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "speckit-test-$(Get-Random)"
-        New-Item -ItemType Directory -Path $tempDir -Force | Out-Null
+        $tempDir = New-SpeckitTestDirectory
         try {
             $result = & $scriptPath -WorkspaceRoot $tempDir | ConvertFrom-Json
             $result.exists | Should Be $false
@@ -25,7 +38,7 @@ Describe 'check-constitution.ps1' {
     }
 
     It 'returns valid=false when constitution has template placeholders' {
-        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "speckit-test-$(Get-Random)"
+        $tempDir = New-SpeckitTestDirectory
         $docsDir = Join-Path $tempDir 'docs'
         New-Item -ItemType Directory -Path $docsDir -Force | Out-Null
         Set-Content (Join-Path $docsDir 'constitution.md') '# Constitution for [PROJECT_NAME]'
@@ -40,7 +53,7 @@ Describe 'check-constitution.ps1' {
     }
 
     It 'returns valid=true when constitution is complete with principles' {
-        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "speckit-test-$(Get-Random)"
+        $tempDir = New-SpeckitTestDirectory
         $docsDir = Join-Path $tempDir 'docs'
         New-Item -ItemType Directory -Path $docsDir -Force | Out-Null
         $content = @"
@@ -66,7 +79,7 @@ All APIs MUST be documented.
     }
 
     It 'returns valid=false when no principle sections exist' {
-        $tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "speckit-test-$(Get-Random)"
+        $tempDir = New-SpeckitTestDirectory
         $docsDir = Join-Path $tempDir 'docs'
         New-Item -ItemType Directory -Path $docsDir -Force | Out-Null
         Set-Content (Join-Path $docsDir 'constitution.md') '# Constitution for MyProject'
@@ -136,28 +149,24 @@ Describe 'speckit-research skill' {
     }
 }
 
-Describe 'speckit-web-researcher agent' {
+Describe 'speckit-research skill ownership' {
     BeforeAll {
         $speckitRoot = Split-Path $PSScriptRoot -Parent
     }
 
-    It 'agent.md exists' {
-        $path = Join-Path $speckitRoot 'agents\speckit-web-researcher.agent.md'
+    It 'research skill owns web research instructions' {
+        $path = Join-Path $speckitRoot 'skills\speckit-research\SKILL.md'
         Test-Path $path | Should Be $true
+        $content = Get-Content $path -Raw
+        $content | Should Match 'web-researcher'
     }
 
-    It 'agent.md has user-invocable false in frontmatter' {
-        $path = Join-Path $speckitRoot 'agents\speckit-web-researcher.agent.md'
+    It 'research skill has structured research dimensions' {
+        $path = Join-Path $speckitRoot 'skills\speckit-research\SKILL.md'
         $content = Get-Content $path -Raw
-        $content | Should Match 'user-invocable:\s*false'
-    }
-
-    It 'agent.md has structured evaluation criteria' {
-        $path = Join-Path $speckitRoot 'agents\speckit-web-researcher.agent.md'
-        $content = Get-Content $path -Raw
-        $content | Should Match 'Maintenance'
-        $content | Should Match 'Popularity'
-        $content | Should Match 'License'
+        $content | Should Match 'Technology choices'
+        $content | Should Match 'Architecture patterns'
+        $content | Should Match 'Security implications'
     }
 }
 
@@ -171,8 +180,8 @@ Describe 'install.ps1 registration' {
         $installContent | Should Match "'speckit-research'"
     }
 
-    It 'registers speckit-web-researcher in Agents array' {
-        $installContent | Should Match "'speckit-web-researcher'"
+    It 'does not use the legacy Agents array' {
+        $installContent | Should Not Match '\$Agents\s*='
     }
 }
 
@@ -197,86 +206,66 @@ Describe 'pipeline wiring for research' {
     }
 }
 
-Describe 'speckit-test agent' {
+Describe 'speckit-test skill' {
     BeforeAll {
         $speckitRoot = Split-Path $PSScriptRoot -Parent
     }
 
-    It 'agent.md exists' {
-        $path = Join-Path $speckitRoot 'agents\speckit-test.agent.md'
+    It 'SKILL.md exists' {
+        $path = Join-Path $speckitRoot 'skills\speckit-test\SKILL.md'
         Test-Path $path | Should Be $true
     }
 
-    It 'agent.md has correct name in frontmatter' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-test.agent.md') -Raw
+    It 'SKILL.md has correct name in frontmatter' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-test\SKILL.md') -Raw
         $content | Should Match 'name:\s*speckit-test'
     }
 
-    It 'old speckit-test skill directory is removed' {
-        $path = Join-Path $speckitRoot 'skills\speckit-test'
-        Test-Path $path | Should Be $false
+    It 'is user invocable' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-test\SKILL.md') -Raw
+        $content | Should Match 'user-invocable:\s*true'
     }
 }
 
-Describe 'speckit-e2e agent' {
+Describe 'speckit-e2e skill' {
     BeforeAll {
         $speckitRoot = Split-Path $PSScriptRoot -Parent
     }
 
-    It 'agent.md exists' {
-        $path = Join-Path $speckitRoot 'agents\speckit-e2e.agent.md'
+    It 'SKILL.md exists' {
+        $path = Join-Path $speckitRoot 'skills\speckit-e2e\SKILL.md'
         Test-Path $path | Should Be $true
     }
 
-    It 'agent.md has correct name in frontmatter' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-e2e.agent.md') -Raw
+    It 'SKILL.md has correct name in frontmatter' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-e2e\SKILL.md') -Raw
         $content | Should Match 'name:\s*speckit-e2e'
     }
 
-    It 'old speckit-e2e skill directory is removed' {
-        $path = Join-Path $speckitRoot 'skills\speckit-e2e'
-        Test-Path $path | Should Be $false
+    It 'is user invocable' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-e2e\SKILL.md') -Raw
+        $content | Should Match 'user-invocable:\s*true'
     }
 }
 
-Describe 'speckit-e2e-browser agent' {
+Describe 'speckit-e2e browser/API guidance' {
     BeforeAll {
         $speckitRoot = Split-Path $PSScriptRoot -Parent
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-e2e\SKILL.md') -Raw
     }
 
-    It 'agent.md exists' {
-        $path = Join-Path $speckitRoot 'agents\speckit-e2e-browser.agent.md'
-        Test-Path $path | Should Be $true
+    It 'documents browser e2e generation' {
+        $content | Should Match 'Playwright'
+        $content | Should Match 'browser'
     }
 
-    It 'agent.md has correct name in frontmatter' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-e2e-browser.agent.md') -Raw
-        $content | Should Match 'name:\s*speckit-e2e-browser'
-    }
-
-    It 'old e2e-recorder agent is removed' {
-        $path = Join-Path $speckitRoot 'agents\speckit-e2e-recorder.agent.md'
-        Test-Path $path | Should Be $false
+    It 'documents API e2e generation' {
+        $content | Should Match 'API'
+        $content | Should Match 'request'
     }
 }
 
-Describe 'speckit-e2e-api agent' {
-    BeforeAll {
-        $speckitRoot = Split-Path $PSScriptRoot -Parent
-    }
-
-    It 'agent.md exists' {
-        $path = Join-Path $speckitRoot 'agents\speckit-e2e-api.agent.md'
-        Test-Path $path | Should Be $true
-    }
-
-    It 'agent.md has correct name in frontmatter' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-e2e-api.agent.md') -Raw
-        $content | Should Match 'name:\s*speckit-e2e-api'
-    }
-}
-
-Describe 'install.ps1 agent registration' {
+Describe 'install.ps1 skill registration' {
     BeforeAll {
         $speckitRoot = Split-Path $PSScriptRoot -Parent
         $installContent = Get-Content (Join-Path $speckitRoot 'install.ps1') -Raw
@@ -290,43 +279,22 @@ Describe 'install.ps1 agent registration' {
         $installContent | Should Match "'speckit-e2e'"
     }
 
-    It 'registers speckit-e2e-browser in Agents array' {
-        $installContent | Should Match "'speckit-e2e-browser'"
-    }
-
-    It 'registers speckit-e2e-api in Agents array' {
-        $installContent | Should Match "'speckit-e2e-api'"
-    }
-
-    It 'registers speckit-web-researcher in Agents array' {
-        $installContent | Should Match "'speckit-web-researcher'"
-    }
-
-    It 'RETRO.TEMPLATE.md still exists in agents/assets (used by speckit-implement at done-done)' {
-        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'agents\assets\RETRO.TEMPLATE.md'
+    It 'RETRO.TEMPLATE.md exists in implement assets (used at done-done)' {
+        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'skills\speckit-implement\assets\RETRO.TEMPLATE.md'
         Test-Path $path | Should Be $true
     }
 
-    It 'PARKING-LOT.TEMPLATE.md still exists in agents/assets (used by speckit-implement at done-done)' {
-        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'agents\assets\PARKING-LOT.TEMPLATE.md'
+    It 'PARKING-LOT.TEMPLATE.md exists in implement assets (used at done-done)' {
+        $path = Join-Path (Split-Path $PSScriptRoot -Parent) 'skills\speckit-implement\assets\PARKING-LOT.TEMPLATE.md'
         Test-Path $path | Should Be $true
     }
 
-    It 'deprecated retro/doctor/loader/scanner/nexus/pipeline-checker agents are removed' {
-        $speckitRoot = Split-Path $PSScriptRoot -Parent
-        foreach ($name in 'speckit-retro','speckit-living-docs-loader','speckit-codebase-scanner','speckit-nexus','speckit-pipeline-checker') {
-            (Test-Path (Join-Path $speckitRoot "agents\$name.agent.md")) | Should Be $false
-        }
+    It 'deprecated doctor skill is removed' {
         (Test-Path (Join-Path $speckitRoot 'skills\speckit-doctor')) | Should Be $false
     }
 
-    It 'does NOT register speckit-e2e-recorder in Agents array' {
+    It 'does NOT register speckit-e2e-recorder' {
         $installContent | Should Not Match "'speckit-e2e-recorder'"
-    }
-
-    It 'does NOT register speckit-test in Skills array' {
-        # speckit-test was moved to agents; should not appear in Skills
-        $installContent -replace '\$Agents[\s\S]*', '' | Should Not Match "'speckit-test'"
     }
 }
 
@@ -350,9 +318,9 @@ Describe 'handoff schema' {
         $content | Should Match 'PipelineContext'
     }
 
-    It 'router SKILL.md references runSubagent for test' {
+    It 'router SKILL.md routes to the test skill' {
         $content = Get-Content (Join-Path $speckitRoot 'SKILL.md') -Raw
-        $content | Should Match 'runSubagent.*speckit-test'
+        $content | Should Match 'route to `speckit-test`'
     }
 }
 
@@ -436,13 +404,13 @@ Describe 'PipelineContext schema (#22) extensions' {
         $content | Should Match 'phaseVerdicts'
     }
 
-    It 'speckit-test agent notes phaseVerdicts.test' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-test.agent.md') -Raw
+    It 'speckit-test skill notes phaseVerdicts.test' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-test\SKILL.md') -Raw
         $content | Should Match 'phaseVerdicts.test'
     }
 
-    It 'speckit-e2e agent notes phaseVerdicts.e2e and e2eEvidenceDir' {
-        $content = Get-Content (Join-Path $speckitRoot 'agents\speckit-e2e.agent.md') -Raw
+    It 'speckit-e2e skill notes phaseVerdicts.e2e and e2eEvidenceDir' {
+        $content = Get-Content (Join-Path $speckitRoot 'skills\speckit-e2e\SKILL.md') -Raw
         $content | Should Match 'phaseVerdicts.e2e'
         $content | Should Match 'e2eEvidenceDir'
     }
@@ -471,6 +439,126 @@ Describe 'verify-marker-budget.ps1' {
         $result.valid | Should Be $false
         $result.violations[0].Phase | Should Be 'plan'
         $result.violations[0].Lines | Should Be 3
+    }
+}
+
+Describe 'before_implement guard (#25)' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot 'invoke-before-implement-guard.ps1'
+    }
+
+    It 'freezes scoped paths from issue body' {
+        $tempDir = New-SpeckitTestDirectory
+        $body = @(
+            '## Scope'
+            ''
+            '- `scripts/invoke-before-pr-guard.ps1`'
+            '- `references/HOOKS.md`'
+        ) -join "`n"
+        try {
+            & $scriptPath -WorkspaceRoot $tempDir -IssueBody $body | Out-Null
+            $freeze = Get-Content (Join-Path $tempDir '.specify\frozen-edit-paths.json') -Raw | ConvertFrom-Json
+            (@($freeze.allowedPaths) -contains 'scripts/invoke-before-pr-guard.ps1') | Should Be $true
+            (@($freeze.allowedPaths) -contains 'references/HOOKS.md') | Should Be $true
+        }
+        finally {
+            Remove-Item $tempDir -Recurse -Force
+        }
+    }
+
+    It 'rejects an empty scope by default' {
+        $tempDir = New-SpeckitTestDirectory
+        try {
+            { & $scriptPath -WorkspaceRoot $tempDir -IssueBody '## Scope' } | Should Throw
+        }
+        finally {
+            Remove-Item $tempDir -Recurse -Force
+        }
+    }
+}
+
+Describe 'before_pr guard (#25)' {
+    BeforeAll {
+        $scriptPath = Join-Path $PSScriptRoot 'invoke-before-pr-guard.ps1'
+    }
+
+    It 'passes when current changes stay inside frozen edit paths' {
+        $tempDir = New-SpeckitTestDirectory
+        try {
+            Push-Location $tempDir
+            git init -b main | Out-Null
+            git config user.email test@example.com
+            git config user.name 'Speckit Test'
+            New-Item -ItemType Directory -Path 'scripts','.specify' -Force | Out-Null
+            Set-Content scripts\guard.ps1 'base'
+            git add -A
+            git commit -m 'chore: seed' | Out-Null
+            git checkout -b feature | Out-Null
+            $freeze = @{ schemaVersion = 1; allowedPaths = @('scripts') } | ConvertTo-Json
+            Set-Content .specify\frozen-edit-paths.json $freeze
+            Set-Content scripts\guard.ps1 'changed'
+            git add scripts\guard.ps1
+            git commit -m 'chore: change guard' | Out-Null
+
+            $result = & $scriptPath -WorkspaceRoot $tempDir -BaseRef main
+            $result | Should Match 'passed'
+        }
+        finally {
+            Pop-Location
+            Remove-Item $tempDir -Recurse -Force
+        }
+    }
+
+    It 'fails when current changes leave frozen edit paths' {
+        $tempDir = New-SpeckitTestDirectory
+        try {
+            Push-Location $tempDir
+            git init -b main | Out-Null
+            git config user.email test@example.com
+            git config user.name 'Speckit Test'
+            New-Item -ItemType Directory -Path 'scripts','.specify' -Force | Out-Null
+            Set-Content scripts\guard.ps1 'base'
+            git add -A
+            git commit -m 'chore: seed' | Out-Null
+            git checkout -b feature | Out-Null
+            $freeze = @{ schemaVersion = 1; allowedPaths = @('scripts') } | ConvertTo-Json
+            Set-Content .specify\frozen-edit-paths.json $freeze
+            Set-Content README.md 'outside'
+            git add README.md
+            git commit -m 'chore: change outside scope' | Out-Null
+
+            { & $scriptPath -WorkspaceRoot $tempDir -BaseRef main } | Should Throw
+        }
+        finally {
+            Pop-Location
+            Remove-Item $tempDir -Recurse -Force
+        }
+    }
+
+    It 'fails on introduced TODO(speckit) markers by default' {
+        $tempDir = New-SpeckitTestDirectory
+        try {
+            Push-Location $tempDir
+            git init -b main | Out-Null
+            git config user.email test@example.com
+            git config user.name 'Speckit Test'
+            New-Item -ItemType Directory -Path 'scripts','.specify' -Force | Out-Null
+            Set-Content scripts\guard.ps1 'base'
+            git add -A
+            git commit -m 'chore: seed' | Out-Null
+            git checkout -b feature | Out-Null
+            $freeze = @{ schemaVersion = 1; allowedPaths = @('scripts') } | ConvertTo-Json
+            Set-Content .specify\frozen-edit-paths.json $freeze
+            Set-Content scripts\guard.ps1 '# TODO(speckit): triage this'
+            git add scripts\guard.ps1
+            git commit -m 'chore: add todo' | Out-Null
+
+            { & $scriptPath -WorkspaceRoot $tempDir -BaseRef main } | Should Throw
+        }
+        finally {
+            Pop-Location
+            Remove-Item $tempDir -Recurse -Force
+        }
     }
 }
 

--- a/skills/speckit-implement/SKILL.md
+++ b/skills/speckit-implement/SKILL.md
@@ -77,6 +77,17 @@ You **MUST** consider the user input before proceeding (if not empty).
 **Check for extension hooks (before implementation)**:
 Follow the [hook execution procedure](../../references/HOOKS.md) with `hookKey = hooks.before_implement`.
 
+**Run bundled frozen-path guard**:
+After loading the GitHub issue body and before editing files, run:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File scripts/invoke-before-implement-guard.ps1 -WorkspaceRoot "." -IssueBody "{issue body markdown}"
+```
+
+This writes `.specify/frozen-edit-paths.json`. If the issue scope names broader
+directories instead of exact files, keep those directories; the `before_pr` guard
+will allow changes beneath them and block unrelated paths.
+
 ## GitHub Issue Gate (MANDATORY)
 
 This skill **requires a GitHub issue number** as input. The issue number can be provided via `$ARGUMENTS` (e.g., `#42` or `42`) or will be prompted for.
@@ -256,6 +267,12 @@ Skip all steps below — they are for the Full Implementation Flow only.
       If either rule fails, edit the PR body via `gh pr edit {pr_number} --body-file ...`
       until both rules pass. Then run extension hooks:
       Follow the [hook execution procedure](../../references/HOOKS.md) with `hookKey = hooks.before_pr`.
+      Run the bundled guard before marking ready:
+      ```powershell
+      powershell -ExecutionPolicy Bypass -File scripts/invoke-before-pr-guard.ps1 -WorkspaceRoot "." -BaseRef "main"
+      ```
+      This fails on deletes/renames, changes outside `.specify/frozen-edit-paths.json`,
+      or introduced `TODO(speckit)` markers that have not been triaged.
 
       Once the body is valid, mark the PR ready for review:
       ```bash

--- a/skills/speckit-implement/assets/pipeline-guard.yml
+++ b/skills/speckit-implement/assets/pipeline-guard.yml
@@ -20,6 +20,11 @@ jobs:
   guard:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
       - name: Validate PR body
         uses: actions/github-script@v7
         with:
@@ -56,3 +61,14 @@ jobs:
             } else {
               core.info('Speckit pipeline guard passed.');
             }
+
+      - name: Run before_pr guard
+        shell: pwsh
+        run: |
+          if (Test-Path ./scripts/invoke-before-pr-guard.ps1) {
+            ./scripts/invoke-before-pr-guard.ps1 -WorkspaceRoot "." -BaseRef "${{ github.event.pull_request.base.sha }}"
+          } elseif (Test-Path ./.github/skills/speckit/scripts/invoke-before-pr-guard.ps1) {
+            ./.github/skills/speckit/scripts/invoke-before-pr-guard.ps1 -WorkspaceRoot "." -BaseRef "${{ github.event.pull_request.base.sha }}"
+          } else {
+            throw "before_pr guard script not found."
+          }


### PR DESCRIPTION
## Linked issue

Closes #25

## What changed

Adds bundled before_implement and before_pr guard hooks for frozen edit paths, destructive-change scanning, and TODO(speckit) triage. Updates hook docs, implement instructions, pipeline guard wiring, and Pester coverage.

## Speckit phases

- [x] **Specify** - issue #25 contains the accepted scope
- [x] **Research** - HOOKS.md and existing pipeline guard surface audited
- [x] **Plan** - implementation scope derived from #25 acceptance criteria
- [x] **Implement** - guard scripts, docs, and workflow wiring complete
- [x] **Test (UAT)** - Pester suite passes
- [x] **E2E** - workflow guard path covered by scripted tests
- [x] **Retro** - no living-doc follow-up beyond HOOKS.md required

## Test results

```text
Invoke-Pester -Path scripts\speckit.tests.ps1
Passed: 58 Failed: 0 Skipped: 0 Pending: 0 Inconclusive: 0
```