### PR TITLE
fix: guard draft project items in issue state sync

### DIFF
--- a/scripts/set-issue-state.ps1
+++ b/scripts/set-issue-state.ps1
@@ -140,7 +140,15 @@ $gqlJqPath = '.data.' + $gqlOwnerRoot + '.projectV2'
 $projectData = (gh api graphql -f query="$projectQuery" --jq "$gqlJqPath") 2>&1 | ConvertFrom-Json
 $projectId = $projectData.id
 
-$projectItem = $projectData.items.nodes | Where-Object { $_.content.id -eq $issueNodeId }
+$projectItem = $projectData.items.nodes | Where-Object {
+    try {
+        $_.content.id -eq $issueNodeId
+    }
+    catch {
+        # Draft items and other non-issue content may not expose .content.id
+        $false
+    }
+}
 
 if (-not $projectItem) {
     Write-Host "  Issue not in project - adding it now..." -ForegroundColor DarkYellow

--- a/scripts/speckit.tests.ps1
+++ b/scripts/speckit.tests.ps1
@@ -562,3 +562,44 @@ Describe 'before_pr guard (#25)' {
     }
 }
 
+Describe 'set-issue-state.ps1 draft item handling' {
+    It 'does not throw when a project item has content without id' {
+        $issueNodeId = 'ISSUE_NODE_123'
+        $items = @(
+            [PSCustomObject]@{ id = 'item-draft'; content = [PSCustomObject]@{} },
+            [PSCustomObject]@{ id = 'item-issue'; content = [PSCustomObject]@{ id = $issueNodeId; number = 36 } }
+        )
+
+        {
+            $null = $items | Where-Object {
+                try {
+                    $_.content.id -eq $issueNodeId
+                }
+                catch {
+                    $false
+                }
+            }
+        } | Should Not Throw
+    }
+
+    It 'finds the matching issue-backed item while skipping draft items' {
+        $issueNodeId = 'ISSUE_NODE_456'
+        $items = @(
+            [PSCustomObject]@{ id = 'item-draft-a'; content = [PSCustomObject]@{} },
+            [PSCustomObject]@{ id = 'item-draft-b'; content = $null },
+            [PSCustomObject]@{ id = 'item-issue'; content = [PSCustomObject]@{ id = $issueNodeId; number = 99 } }
+        )
+
+        $result = $items | Where-Object {
+            try {
+                $_.content.id -eq $issueNodeId
+            }
+            catch {
+                $false
+            }
+        }
+
+        $result.id | Should Be 'item-issue'
+    }
+}
+


### PR DESCRIPTION
﻿## Summary
Fixes a crash in scripts/set-issue-state.ps1 when GitHub Project draft items are present.

## What changed
- Hardened project item filtering in scripts/set-issue-state.ps1 by wrapping content.id access in 	ry/catch and skipping non-issue content.
- Added regression tests in scripts/speckit.tests.ps1 for draft/non-issue items missing content.id.

## Validation
- Invoke-Pester -Path scripts/speckit.tests.ps1 passed (60 tests).

Closes #36

## Speckit Phases
- [x] **Specify**
- [ ] **Research**
- [ ] **Plan**
- [x] **Implement**
- [x] **Test**
- [ ] **E2E**
- [ ] **Retro**

skip-speckit: research — small targeted script bug with clear root cause and no domain unknowns
skip-speckit: plan — lightweight bug fix did not require design planning artifacts
skip-speckit: e2e — PowerShell script-only change validated via Pester unit/regression tests
skip-speckit: retro — no docs/data model/contracts impact for this scoped script fix
