### PR TITLE
chore: add changelog entry for v3.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [v3.1.1] - 2026-05-01
+
+### Fixed
+- Hardened `scripts/set-issue-state.ps1` to safely skip GitHub Project draft items that do not expose `content.id`, preventing property-access crashes during issue-item lookup.
+- Added regression tests in `scripts/speckit.tests.ps1` to verify draft/non-issue project items are ignored without exceptions while issue-backed items are still matched correctly.


### PR DESCRIPTION
﻿## Summary
Adds release notes for 3.1.1 in a new root changelog.

## Validation
- Docs-only change; no runtime behavior impact.

Closes #38

## Speckit Phases
- [x] **Specify**
- [ ] **Research**
- [ ] **Plan**
- [x] **Implement**
- [x] **Test**
- [ ] **E2E**
- [ ] **Retro**

skip-speckit: research — docs-only follow-up with no technical unknowns
skip-speckit: plan — straightforward changelog entry
skip-speckit: e2e — not applicable to docs-only change
skip-speckit: retro — no architecture/data/contract changes
