### PR TITLE
chore: auto-release on every merge to main via GitHub Actions

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,0 +1,65 @@
+name: Auto Release
+
+# Creates a GitHub Release with a semver tag on every push to main.
+# Version bump is derived from the squashed merge-commit message prefix:
+#   feat!: / BREAKING CHANGE  → major
+#   feat:                      → minor
+#   anything else              → patch
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0          # need full history to read all tags
+
+      - name: Determine next version
+        id: semver
+        run: |
+          # ── Latest tag ────────────────────────────────────────────────
+          LATEST=$(git tag --list 'v*' --sort=-v:refname | head -n1)
+          if [[ -z "$LATEST" ]]; then
+            LATEST="v0.0.0"
+          fi
+          echo "Latest tag: $LATEST"
+
+          MAJOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f1)
+          MINOR=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f2)
+          PATCH=$(echo "$LATEST" | sed 's/^v//' | cut -d. -f3)
+
+          # ── Bump type from commit message ─────────────────────────────
+          MSG=$(git log -1 --format='%B')
+          echo "Commit message: $MSG"
+
+          if echo "$MSG" | grep -qiE '^feat(\([^)]*\))?!:|BREAKING CHANGE'; then
+            BUMP="major"
+            MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0
+          elif echo "$MSG" | grep -qiE '^feat(\([^)]*\))?:'; then
+            BUMP="minor"
+            MINOR=$((MINOR + 1)); PATCH=0
+          else
+            BUMP="patch"
+            PATCH=$((PATCH + 1))
+          fi
+
+          NEXT="v${MAJOR}.${MINOR}.${PATCH}"
+          echo "Bump: $BUMP  →  $NEXT"
+          echo "next_version=$NEXT" >> "$GITHUB_OUTPUT"
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release create "${{ steps.semver.outputs.next_version }}" \
+            --title "${{ steps.semver.outputs.next_version }}" \
+            --generate-notes \
+            --latest


### PR DESCRIPTION
## Summary

Adds `.github/workflows/auto-release.yml` — a GitHub Actions workflow that fires on every push to `main` and creates a semver GitHub Release automatically.

### Bump logic (derived from squashed commit message prefix)

| Commit prefix | Bump |
|---|---|
| `feat!:` or body contains `BREAKING CHANGE` | **major** |
| `feat:` | **minor** |
| `fix:`, `chore:`, `docs:`, `refactor:`, etc. | **patch** |

### Notes
- Uses only `ubuntu-latest` (no self-hosted runners — GHA cost discipline).
- Uses `--generate-notes` so each release body lists the PRs and commits merged since the previous tag.
- `GH_TOKEN` is the built-in `secrets.GITHUB_TOKEN`; no PAT required.

Closes #48

---

## Speckit pipeline checklist

- [x] **speckit-specify** — Issue #48
- [x] **speckit-implement** — this PR
- skip-speckit: speckit-research — conventional semver bump pattern; no unknowns
- skip-speckit: speckit-plan — single new YAML file; no design decisions needed
- [ ] **speckit-test** (UAT) — verified by the first merge that triggers the workflow
- skip-speckit: speckit-e2e — live GHA run on merge is the evidence artifact
